### PR TITLE
Сorrect processing 201 response

### DIFF
--- a/200.js
+++ b/200.js
@@ -4,7 +4,7 @@ var httpStatus = require('http-status-codes')
 module.exports = function only200 (options, callback) {
   dhttp(options, function (err, result) {
     if (err) return callback(err)
-    if (result.statusCode !== 200) {
+    if (result.statusCode !== 200 && result.statusCode !== 201) {
       var message = result.body
       if (!message) message = httpStatus.getStatusText(result.statusCode)
 


### PR DESCRIPTION
sometimes server returns 201 instead of 200, which is also a correct answer (for example ttps://api.blockcypher.com/v1/btc/test3/txs/push)